### PR TITLE
community: yohey-w lane-recheck placeholder

### DIFF
--- a/cookbook/community/yohey-w/lane-recheck.md
+++ b/cookbook/community/yohey-w/lane-recheck.md
@@ -1,0 +1,10 @@
+# lane-recheck
+
+修正検証用・すぐ削除 / Verification of the take-down lane fix — delete immediately.
+
+このファイルは `community-remove.yml` の修正（起動口・重複ガード・テンプレ）を
+実弾で1周するためだけに置いた無害なプレースホルダです。検証が終わり次第、
+削除レーン自身によって取り除かれます。
+
+This is a harmless placeholder, filed only to run the removal lane once end to
+end after its fix. It is removed by the removal lane itself as part of the test.


### PR DESCRIPTION
修正検証用・すぐ削除。削除レーン修正の実弾検証のためのプレースホルダで、検証後に削除レーン自身が取り除きます。 / Harmless placeholder for verifying the take-down lane fix; removed by the lane itself.