### PR TITLE
community: yohey-w lane-recheck placeholder (2)

### DIFF
--- a/cookbook/community/yohey-w/lane-recheck.md
+++ b/cookbook/community/yohey-w/lane-recheck.md
@@ -1,0 +1,9 @@
+# lane-recheck
+
+修正検証用・すぐ削除 / Verification of the take-down lane fix — delete immediately.
+
+2周目。ラベルを付けずに起票したときに、issue テンプレ本文のマーカーだけで
+削除レーンが起動するかを確かめるためのプレースホルダです。
+
+Second pass. A harmless placeholder used to check that the take-down lane wakes
+up from the issue-body marker alone, with no label applied at filing time.


### PR DESCRIPTION
修正検証用・すぐ削除。マーカー起動口の検証用プレースホルダで、検証後に削除レーン自身が取り除きます。 / Harmless placeholder for the marker-door check; removed by the lane itself.